### PR TITLE
First proposal of injected EventStore

### DIFF
--- a/src/FeedStore.js
+++ b/src/FeedStore.js
@@ -1,28 +1,31 @@
 'use strict'
 
-const EventStore = require('orbit-db-eventstore')
 const FeedIndex  = require('./FeedIndex')
 
-class FeedStore extends EventStore {
-  constructor (ipfs, id, dbname, options) {
-    if(!options) options = {}
-    if(!options.Index) Object.assign(options, { Index: FeedIndex })
-    super(ipfs, id, dbname, options)
-    this._type = 'feed'
-  }
-
-  remove (hash, options = {}) {
-    return this.del(hash, options)
-  }
-
-  del (hash, options = {}) {
-    const operation = {
-      op: 'DEL',
-      key: null,
-      value: hash
+const genFeedStore = function(EventStore) {
+  class FeedStore extends EventStore {
+    constructor (ipfs, id, dbname, options) {
+      if(!options) options = {}
+      if(!options.Index) Object.assign(options, { Index: FeedIndex })
+      super(ipfs, id, dbname, options)
+      this._type = 'feed'
     }
-    return this._addOperation(operation, options)
+
+    remove (hash, options = {}) {
+      return this.del(hash, options)
+    }
+
+    del (hash, options = {}) {
+      const operation = {
+        op: 'DEL',
+        key: null,
+        value: hash
+      }
+      return this._addOperation(operation, options)
+    }
   }
+  return FeedStore
 }
 
-module.exports = FeedStore
+
+module.exports = genFeedStore


### PR DESCRIPTION
This is my first try at injecting dependencies as suggested in [#899](https://github.com/orbitdb/orbit-db/issues/899). Is this what you had in mind?

As of now, it replaces the `FeedStore` class with a function that takes an `EventStore` class and generates a `FeedStore` class. 

Also, would it be best to leave `const EventStore = require('orbit-db-eventstore')` as the default EventStore if none is specified?