### PR TITLE
Publish next version to npm

### DIFF
--- a/.github/workflows/npm-publish-next.yml
+++ b/.github/workflows/npm-publish-next.yml
@@ -1,0 +1,24 @@
+---
+name: Node.js Package (next tag)
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: |
+          npm version prerelease --no-git-tag-version \
+            --preid=`git rev-parse --short HEAD`
+          npm publish --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
This PR adds a Github Action to publish the module to npm with tag "next" upon pushing changes to main.